### PR TITLE
Disable Add Photo submit button when input is not complete

### DIFF
--- a/photo-client/src/Components/AddPhoto.js
+++ b/photo-client/src/Components/AddPhoto.js
@@ -67,13 +67,14 @@ class AddPhoto extends Component {
     }
 
     render() {
+        const isSubmitEnabled = this.state.name !== '' && this.state.file !== undefined;
         return (
             <fieldset>
                 <Form onSubmit={this.handleSubmit}>
                     <Form.Group >
                         <Form.Input label="Friendly name" type="text" placeholder="Title" value={this.state.name} onChange={this.handleChange.bind(this, 'name')} />
                         <Form.Input key={this.state.lastUpdate} label="File to upload" type="file" onChange={this.handleChange.bind(this, 'file')} />
-                        <Form.Button icon labelPosition="right" label="GraphQL mutation" type="submit"><Icon name="upload" />Add Photo</Form.Button>
+                        <Form.Button icon labelPosition="right" label="GraphQL mutation" type="submit" disabled={!isSubmitEnabled}><Icon name="upload" />Add Photo</Form.Button>
                     </Form.Group>
                 </Form>
             </fieldset>


### PR DESCRIPTION
- Currently when clicking the Add Photo button without a photo uploaded or 'Friendly name' input the API response returns a 400 Bad Request
- This PR adds basic validation to the submit button to check if content has been added. If both inputs required for photo upload have content then the photo upload submit button is enabled