### PR TITLE
Remove aws-sdk from package.json

### DIFF
--- a/photo-client/package.json
+++ b/photo-client/package.json
@@ -7,7 +7,6 @@
     "aws-amplify-react": "^0.1.39",
     "aws-appsync": "^1.0.23",
     "aws-appsync-react": "^1.0.5",
-    "aws-sdk": "^2.177.0",
     "graphql-tag": "^2.6.1",
     "react": "^16.2.0",
     "react-apollo": "^2.0.4",


### PR DESCRIPTION
Hi,

I tried the photo-client sample application in this repository and I found that clicking the link in the all-photo-list does not work and shows error "missing credentials in config".

According to [this issue](https://github.com/aws-amplify/amplify-js/issues/1241), it caused by existing  aws-sdk in node_modules, and I confirmed that the application would work properly after I removed it.

I think there is no need to import aws-sdk in this photo-client sample, so please check it.

Thank you in advance😀